### PR TITLE
Various changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![NPM version][npm-image]][npm-url]
 [![npm download][download-image]][download-url]
+[![build status][ci-image]][ci-url]
+[![Test coverage][codecov-image]][codecov-url]
 
 Polynomial Regression.
 
@@ -12,7 +14,7 @@ Polynomial Regression.
 ## Usage
 
 ```js
-import PolynomialRegression from 'ml-regression-polynomial';
+import { PolynomialRegression } from 'ml-regression-polynomial';
 
 const x = [50, 50, 50, 70, 70, 70, 80, 80, 80, 90, 90, 90, 100, 100, 100];
 const y = [3.3, 2.8, 2.9, 2.3, 2.6, 2.1, 2.5, 2.9, 2.4, 3.0, 3.1, 2.8, 3.3, 3.5, 3.0];
@@ -35,3 +37,7 @@ console.log(regression.score(x, y));
 [npm-url]: https://npmjs.org/package/ml-regression-polynomial
 [download-image]: https://img.shields.io/npm/dm/ml-regression-polynomial.svg?style=flat-square
 [download-url]: https://npmjs.org/package/ml-regression-polynomial
+[codecov-image]: https://img.shields.io/codecov/c/github/mljs/regression-polynomial.svg
+[codecov-url]: https://codecov.io/gh/mljs/regression-polynomial
+[ci-image]: https://github.com/mljs/regression-polynomial/workflows/Node.js%20CI/badge.svg?branch=master
+[ci-url]: https://github.com/mljs/regression-polynomial/actions?query=workflow%3A%22Node.js+CI%22

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Polynomial Regression.
 import { PolynomialRegression } from 'ml-regression-polynomial';
 
 const x = [50, 50, 50, 70, 70, 70, 80, 80, 80, 90, 90, 90, 100, 100, 100];
-const y = [3.3, 2.8, 2.9, 2.3, 2.6, 2.1, 2.5, 2.9, 2.4, 3.0, 3.1, 2.8, 3.3, 3.5, 3.0];
+const y = [
+  3.3, 2.8, 2.9, 2.3, 2.6, 2.1, 2.5, 2.9, 2.4, 3.0, 3.1, 2.8, 3.3, 3.5, 3.0,
+];
 const degree = 5; // setup the maximum degree of the polynomial
 
 const regression = new PolynomialRegression(x, y, degree);
@@ -28,6 +30,29 @@ console.log(regression.toString(3)); // Prints a human-readable version of the f
 console.log(regression.toLaTeX());
 console.log(regression.score(x, y));
 ```
+
+## Options
+
+An `interceptAtZero` option is available, to force $f(0) = 0$. Also, a "powers array" can be specified.
+
+- Using `interceptAtZero`
+
+```js
+const regression = new PolynomialRegression(x, y, degree, {
+  interceptAtZero: true,
+});
+```
+
+- Using the powers array
+
+```js
+const powers = [0, 1, 2, 3, 4, 5];
+const regression = new PolynomialRegression(x, y, powers);
+```
+
+`powers` could also be `[1,2,3,4,5]`or`[1,3,5]` and so on.
+
+For intercepting at zero using an array, skip the zero in the array (the option `interceptAtZero` is ignored in this case.)
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -30,15 +30,16 @@
   },
   "homepage": "https://github.com/mljs/regression-polynomial#readme",
   "devDependencies": {
-    "@babel/plugin-transform-modules-commonjs": "^7.16.8",
-    "eslint": "^8.10.0",
-    "eslint-config-cheminfo": "^7.2.2",
-    "jest": "^27.5.1",
-    "prettier": "^2.5.1",
-    "rollup": "^2.69.0"
+    "@babel/plugin-transform-modules-commonjs": "^7.23.0",
+    "eslint": "^8.50.0",
+    "eslint-config-cheminfo": "^9.0.2",
+    "jest": "^29.7.0",
+    "prettier": "^3.0.3",
+    "rollup": "^3.29.3"
   },
   "dependencies": {
-    "ml-matrix": "^6.9.0",
-    "ml-regression-base": "^2.1.6"
+    "@jest/globals": "^29.7.0",
+    "ml-matrix": "^6.10.5",
+    "ml-regression-base": "^3.0.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,4 +4,5 @@ export default {
     file: 'lib/index.js',
     format: 'cjs',
   },
+  external: ['ml-regression-base', 'ml-matrix'],
 };

--- a/src/__tests__/test.js
+++ b/src/__tests__/test.js
@@ -1,17 +1,24 @@
-import PolynomialRegression from '..';
+import { expect, describe, it } from '@jest/globals';
+
+import { PolynomialRegression } from '..';
+
+function assertCoefficientsAndPowers(result, expectedCs, expectedPowers) {
+  let i = 0;
+  for (i; i < expectedCs.length; ++i) {
+    expect(result.coefficients[i]).toBeCloseTo(expectedCs[i], 10e-6);
+    expect(result.powers).toStrictEqual(expectedPowers);
+  }
+  expect(result.degree).toBe(Math.max(...expectedPowers));
+}
 
 describe('Polynomial regression', () => {
   it('degree 2', () => {
     const x = [-3, 0, 2, 4];
     const y = [3, 1, 1, 3];
     const result = new PolynomialRegression(x, y, 2);
-
     const expected = [0.850519, -0.192495, 0.178462];
 
-    for (let i = 0; i < expected.length; ++i) {
-      expect(result.coefficients[i]).toBeCloseTo(expected[i], 10e-6);
-      expect(result.powers[i]).toBe(i);
-    }
+    assertCoefficientsAndPowers(result, expected, [0, 1, 2]);
 
     const score = result.score(x, y);
     expect(score.r2).toBeGreaterThan(0.8);
@@ -30,10 +37,7 @@ describe('Polynomial regression', () => {
 
     const expected = [0.850519, -0.192495, 0.178462];
 
-    for (let i = 0; i < expected.length; ++i) {
-      expect(result.coefficients[i]).toBeCloseTo(expected[i], 10e-6);
-      expect(result.powers[i]).toBe(i);
-    }
+    assertCoefficientsAndPowers(result, expected, [0, 1, 2]);
 
     const score = result.score(x, y);
     expect(score.r2).toBeGreaterThan(0.8);
@@ -79,5 +83,26 @@ describe('Polynomial regression', () => {
       powers: [1],
       coefficients: [-1],
     });
+  });
+  it('Fit a parabola with origin on 0', () => {
+    const x = new Float64Array([-4, 4, 2, 3, 1, 8, 5, 7]);
+    const y = new Float64Array([16.5, 16.5, 4.5, 9.5, 1.5, 64.5, 25.5, 49.5]);
+    const result = new PolynomialRegression(x, y, 2, { interceptAtZero: true });
+    const solution = [0.018041553971009705, 1.0095279075485593];
+    assertCoefficientsAndPowers(result, solution, [1, 2]);
+  });
+  it('Fit a parabola with origin on 0, using degree array', () => {
+    const x = new Float64Array([-4, 4, 2, 3, 1, 8, 5, 7]);
+    const y = new Float64Array([16.5, 16.5, 4.5, 9.5, 1.5, 64.5, 25.5, 49.5]);
+    const result = new PolynomialRegression(x, y, [1, 2]);
+    const solution = [0.018041553971009705, 1.0095279075485593];
+    assertCoefficientsAndPowers(result, solution, [1, 2]);
+  });
+  it('Fit a parabola inverting the degree array terms', () => {
+    const x = new Float64Array([-4, 4, 2, 3, 1, 8, 5, 7]);
+    const y = new Float64Array([16.5, 16.5, 4.5, 9.5, 1.5, 64.5, 25.5, 49.5]);
+    const result = new PolynomialRegression(x, y, [2, 1]);
+    const solution = [1.0095279075485593, 0.018041553971009705];
+    assertCoefficientsAndPowers(result, solution, [2, 1]);
   });
 });

--- a/src/__tests__/test.js
+++ b/src/__tests__/test.js
@@ -1,6 +1,6 @@
 import { expect, describe, it } from '@jest/globals';
 
-import PolynomialRegression from '..';
+import { PolynomialRegression } from '..';
 
 function assertCoefficientsAndPowers(result, expectedCs, expectedPowers) {
   let i = 0;

--- a/src/__tests__/test.js
+++ b/src/__tests__/test.js
@@ -1,6 +1,6 @@
 import { expect, describe, it } from '@jest/globals';
 
-import { PolynomialRegression } from '..';
+import PolynomialRegression from '..';
 
 function assertCoefficientsAndPowers(result, expectedCs, expectedPowers) {
   let i = 0;

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import BaseRegression, {
   maybeToPrecision,
 } from 'ml-regression-base';
 
-export default class PolynomialRegression extends BaseRegression {
+export class PolynomialRegression extends BaseRegression {
   constructor(x, y, degree, options = {}) {
     super();
     if (x === true) {

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import BaseRegression, {
   maybeToPrecision,
 } from 'ml-regression-base';
 
-export class PolynomialRegression extends BaseRegression {
+export default class PolynomialRegression extends BaseRegression {
   constructor(x, y, degree, options = {}) {
     super();
     if (x === true) {


### PR DESCRIPTION
**Changes**

* refactor!: use named exports to ease transition to Typescript (hopefully next pr is not breaking.)
* fix: determine the degree from max power, not power length
* feat: allow users to pass `interceptAtZero` parameter
* refactor: `regress` independent from the class instance 


**Other changes**

* test: add tests for the new parameter
* update dependencies
* add externals to Rollup externals
* add flags and examples to the Readme    


----------

## Note
I tested the `import/export`, and seems to work correctly in NodeJS v19:

```javascript
const { PolynomialRegression } = require("ml-regression-polynomial");

const x = [1, 2, 3, 4, 5, 6];
const y = [1, 4, 9, 16, 25, 36];
console.log(new PolynomialRegression(x, y, [2]));
```

```bash
lap@top:~/clones/test$ node index.js 
PolynomialRegression { degree: 2, powers: [ 2 ], coefficients: [ 1 ] }

lap@top:~/clones/test$ node index.mjs 
PolynomialRegression { degree: 2, powers: [ 2 ], coefficients: [ 1 ] }
```


It closes #1